### PR TITLE
FIX disable network access from the container

### DIFF
--- a/backend/src/handler.go
+++ b/backend/src/handler.go
@@ -75,7 +75,7 @@ func (h *Handler) GetExecutionSteps(ctx context.Context, req GetExecutionStepsRe
 	outputMapping := fmt.Sprintf("%s/%s/output:/root/output", currentDir, dataDir)
 	deadlineCtx, cancel := context.WithTimeout(ctx, 300*time.Second)
 	defer cancel()
-	dockerCommand := exec.CommandContext(deadlineCtx, "docker", "run", "--rm", "-v", sourceCodeMapping, "-v", outputMapping, "ahmedakef/gotutor", "debug", "/data/main.go")
+	dockerCommand := exec.CommandContext(deadlineCtx, "docker", "run", "--rm", "--network", "none", "-v", sourceCodeMapping, "-v", outputMapping, "ahmedakef/gotutor", "debug", "/data/main.go")
 	out, err := dockerCommand.CombinedOutput()
 	outStr := string(out)
 	if outputSanitized, ok := outputContainsError(outStr); ok {


### PR DESCRIPTION
there is no restrictions on network calls

example code:
```go
package main

import (
	"fmt"
	"io/ioutil"
	"net/http"
	"time"
)

func main() {
	c := http.Client{Timeout: time.Duration(1) * time.Second}
	resp, err := c.Get("https://www.google.com")

	if err != nil {
		fmt.Printf("Error %s", err)
		return
	}

	defer resp.Body.Close()
	body, err := ioutil.ReadAll(resp.Body)
	fmt.Printf("Body: %s", body)
}

```